### PR TITLE
feat: add ImagePullSecrets config private registries

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -65,6 +65,14 @@ func (p Provider) CreateInstance(_ context.Context, bootstrapParams params.Boots
 		},
 	}
 
+	if len(config.Config.ImagePullSecrets) > 0 {
+		var secrets []corev1.LocalObjectReference
+		for _, name := range config.Config.ImagePullSecrets {
+			secrets = append(secrets, corev1.LocalObjectReference{Name: name})
+		}
+		pod.Spec.ImagePullSecrets = secrets
+	}
+
 	err = p.ensureNamespace(config.Config.RunnerNamespace)
 	if err != nil {
 		return params.ProviderInstance{}, fmt.Errorf("ensuring runner namespace %s failed: %w", config.Config.RunnerNamespace, err)
@@ -103,7 +111,7 @@ func (p Provider) ensureNamespace(runnerNamespace string) error {
 		return err
 	}
 
-	// if namespace doesn't exists
+	// if namespace doesn't exist
 	// there is no need for creating again
 	if apierrors.IsNotFound(err) {
 		_, err = p.ClientSet.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ import (
 type ProviderConfig struct {
 	KubeConfigPath    string                 `koanf:"kubeConfigPath"`
 	ContainerRegistry string                 `koanf:"containerRegistry"`
+	ImagePullSecrets  []string               `koanf:"imagePullSecrets"`
 	RunnerNamespace   string                 `koanf:"runnerNamespace"`
 	PodTemplate       corev1.PodTemplateSpec `koanf:"podTemplate"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -92,6 +92,31 @@ runnerNamespace: "this_is_An_invalid_namespace_name"
 `,
 			wantError: true,
 		},
+		{
+			name: "valid configuration with imagePullSecrets",
+			expected: config.ProviderConfig{
+				KubeConfigPath:    "/path/to/kubeconfig",
+				ContainerRegistry: "sample.registry.com",
+				RunnerNamespace:   "test-namespace",
+				PodTemplate: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{},
+					},
+				},
+				ImagePullSecrets: []string{
+					"my-imagepullsecret1",
+					"my-imagepullsecret2",
+				},
+			},
+			config: `
+kubeConfigPath: "/path/to/kubeconfig"
+containerRegistry: "sample.registry.com"
+runnerNamespace: "test-namespace"
+imagePullSecrets:
+  - my-imagepullsecret1
+  - my-imagepullsecret2
+`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -114,6 +139,7 @@ runnerNamespace: "this_is_An_invalid_namespace_name"
 				assert.Equal(t, tc.expected.ContainerRegistry, config.Config.ContainerRegistry)
 				assert.Equal(t, tc.expected.RunnerNamespace, config.Config.RunnerNamespace)
 				assert.Equal(t, tc.expected.PodTemplate, config.Config.PodTemplate)
+				assert.Equal(t, tc.expected.ImagePullSecrets, config.Config.ImagePullSecrets)
 			}
 
 			// empty the global config for the next run


### PR DESCRIPTION
One can now supply a list of ImagePullSecrets for runner pods in the provider-config.yaml which are attached to a runner pod if configured, so images can be pulled from private registries as well:

```yaml
kubeConfigPath: "/path/to/kubeconfig"
containerRegistry: "sample.registry.com"
runnerNamespace: "test-namespace"
imagePullSecrets:
  - my-imagepullsecret1
  - my-imagepullsecret2
```