### PR TITLE
fix: kind cluster name must be match exactly

### DIFF
--- a/hack/scripts/kind-with-registry.sh
+++ b/hack/scripts/kind-with-registry.sh
@@ -20,7 +20,7 @@ fi
 KIND_CLUSTER_NAME=${GARM_KIND_CLUSTER_NAME:-"garm"}
 
 # 1. If kind cluster already exists exit.
-if [[ "$(kind get clusters)" =~ .*"${KIND_CLUSTER_NAME}".* ]]; then
+if [[ "$(kind get clusters)" = "${KIND_CLUSTER_NAME}" ]]; then
   echo "kind cluster already exists, moving on"
   exit 0
 fi


### PR DESCRIPTION
We should match on the exact cluster name (instead of doing some wildcard matching).
The current implementation wouldn't create the dedicated `garm` kind cluster if there is already a cluster with a similar name (e.g. `garm-operator`)