### PR TITLE
fix: exclude debug information and sourcemaps in final build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,8 @@ builds:
       - amd64
       - arm64
     main: ./cmd/garm-provider-k8s
+    ldflags:
+      - -s -w
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
reduces final binary size from 48MB to 34MB by stripping away unnecessary debug metadata. 
Tested further compression of binary locally with [upx](https://github.com/upx/upx) which resulted in a final size of only 13MB. 