### PR TITLE
chore: use garm-operator to init garm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ endif
 
 .PHONY: prepare-operator
 prepare-operator: ## Prepare garm-operator for local development
-	curl -L https://github.com/mercedes-benz/garm-operator/releases/download/v0.1.3/garm_operator_all.yaml | \
+	curl -L https://github.com/mercedes-benz/garm-operator/releases/download/v0.2.0/garm_operator_all.yaml | \
 	GARM_SERVER_URL=http://garm-server.garm-server.svc:9997 \
 	GARM_SERVER_USERNAME=admin \
 	GARM_SERVER_PASSWORD=LmrBG1KcBOsDfNKq4cQTGpc0hJ0kejkk \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <!-- SPDX-License-Identifier: MIT -->
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/mercedes-benz/garm-operator)](https://goreportcard.com/report/github.com/mercedes-benz/garm-provider-k8s) 
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/mercedes-benz/garm-provider-k8s?sort=semver)
+[![build](https://github.com/mercedes-benz/garm-provider-k8s/actions/workflows/build.yaml/badge.svg)](https://github.com/mercedes-benz/garm-provider-k8s/actions/workflows/build.yaml)
+
 # garm-provider-k8s
 
 <!-- toc -->

--- a/hack/local-development/kubernetes/garm-operator-all.yaml
+++ b/hack/local-development/kubernetes/garm-operator-all.yaml
@@ -567,6 +567,154 @@ spec:
     subresources:
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: garm-operator-system/garm-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: runners.garm-operator.mercedes-benz.com
+spec:
+  group: garm-operator.mercedes-benz.com
+  names:
+    categories:
+    - garm
+    kind: Runner
+    listKind: RunnerList
+    plural: runners
+    shortNames:
+    - run
+    singular: runner
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Runner ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Pool CR Name
+      jsonPath: .status.poolId
+      name: Pool
+      type: string
+    - description: Garm Runner Status
+      jsonPath: .status.status
+      name: Garm Runner Status
+      type: string
+    - description: Provider Runner Status
+      jsonPath: .status.instanceStatus
+      name: Provider Runner Status
+      type: string
+    - description: Provider ID
+      jsonPath: .status.providerId
+      name: Provider ID
+      priority: 1
+      type: string
+    - description: Agent ID
+      jsonPath: .status.agentId
+      name: Agent ID
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Runner is the Schema for the runners API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RunnerSpec defines the desired state of Runner
+            type: object
+          status:
+            description: RunnerStatus defines the observed state of Runner
+            properties:
+              addresses:
+                description: Addresses is a list of IP addresses the provider reports
+                  for this instance.
+                items:
+                  properties:
+                    address:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              agentId:
+                description: AgentID is the github runner agent ID.
+                format: int64
+                type: integer
+              githubRunnerGroup:
+                description: GithubRunnerGroup is the github runner group to which
+                  the runner belongs. The runner group must be created by someone
+                  with access to the enterprise.
+                type: string
+              id:
+                description: ID is the database ID of this instance.
+                type: string
+              instanceStatus:
+                description: RunnerStatus is the github runner status as it appears
+                  on GitHub.
+                type: string
+              name:
+                description: Name is the name associated with an instance. Depending
+                  on the provider, this may or may not be useful in the context of
+                  the provider, but we can use it internally to identify the instance.
+                type: string
+              osArch:
+                description: OSArch is the operating system architecture.
+                type: string
+              osName:
+                description: 'OSName is the name of the OS. Eg: ubuntu, centos, etc.'
+                type: string
+              osType:
+                description: OSType is the operating system type. For now, only Linux
+                  and Windows are supported.
+                type: string
+              osVersion:
+                description: OSVersion is the version of the operating system.
+                type: string
+              poolId:
+                description: PoolID is the ID of the garm pool to which a runner belongs.
+                type: string
+              providerFault:
+                description: ProviderFault holds any error messages captured from
+                  the IaaS provider that is responsible for managing the lifecycle
+                  of the runner.
+                type: string
+              providerId:
+                description: PeoviderID is the unique ID the provider associated with
+                  the compute instance. We use this to identify the instance in the
+                  provider.
+                type: string
+              status:
+                description: 'Status is the status of the instance inside the provider
+                  (eg: running, stopped, etc)'
+                type: string
+            required:
+            - agentId
+            - githubRunnerGroup
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
 apiVersion: v1
 automountServiceAccountToken: false
 kind: ServiceAccount
@@ -750,6 +898,32 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - garm-operator.mercedes-benz.com
+  resources:
+  - runners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - garm-operator.mercedes-benz.com
+  resources:
+  - runners/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - garm-operator.mercedes-benz.com
+  resources:
+  - runners/status
+  verbs:
+  - get
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -863,7 +1037,7 @@ spec:
         - --operator-watch-namespace=garm-operator-system
         command:
         - /manager
-        image: ghcr.io/mercedes-benz/garm-operator/garm-operator:v0.1.3
+        image: ghcr.io/mercedes-benz/garm-operator/garm-operator:v0.2.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/hack/scripts/entrypoint.sh
+++ b/hack/scripts/entrypoint.sh
@@ -7,17 +7,7 @@ alias garm=/opt/garm/bin/garm
 if [ "$DEBUG" = "true" ]; then
   # build garm as follows for dlv to work
   # go build -gcflags="all=-N -l" -mod vendor -o $BIN_DIR/garm -tags osusergo,netgo,sqlite_omit_load_extension -ldflags "-linkmode external -extldflags '-static' -X main.Version=$(git describe --always --dirty)" .
-  /home/mb/bin/garm/dlv --listen=:40000 --headless=true --api-version=2 --accept-multiclient exec /home/mb/bin/garm/garm -- -config /home/mb/bin/garm/config.toml &
+  /home/mb/bin/garm/dlv --listen=:40000 --headless=true --api-version=2 --accept-multiclient exec /home/mb/bin/garm/garm -- -config /home/mb/bin/garm/config.toml
 else
-  /opt/garm/bin/garm -config /opt/garm/config/config.toml &
+  /opt/garm/bin/garm -config /opt/garm/config/config.toml
 fi
-
-sleep 5
-
-# TODO: remove this once https://github.com/mercedes-benz/garm-operator/pull/30 got merged and
-# extend the local dev-setup script to do the initialization via the operator
-gcli init -e=garm@mercedes-benz.com -n admin -p'LmrBG1KcBOsDfNKq4cQTGpc0hJ0kejkk' -a http://127.0.0.1:9997 -u admin --debug
-
-while true; do
-  sleep 10
-done


### PR DESCRIPTION
for local development, we are using the latest garm-operator release where garm-operator initiate a garm instance per default