### PR TITLE
Add system-info callback

### DIFF
--- a/runner/upstream/Dockerfile
+++ b/runner/upstream/Dockerfile
@@ -4,6 +4,8 @@ FROM ghcr.io/actions/actions-runner:2.311.0
 
 USER root
 
+RUN apt-get update && apt-get install -y curl && apt-get clean
+
 COPY entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
A new callback is available in garm which allows runners to send info about themselves while installing. This new callback allows instances to report their os_name, os_version and the GH agent_id.

See https://github.com/cloudbase/garm/pull/200

This change also makes sure that curl is installed in the image, otherwise the entrypoint will fail.