### PR TITLE
refactor: remove container registry config

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,7 +31,6 @@ type Provider struct {
 func (p Provider) CreateInstance(_ context.Context, bootstrapParams params.BootstrapInstance) (params.ProviderInstance, error) {
 	podName := strings.ToLower(bootstrapParams.Name)
 	labels := spec.ParamsToPodLabels(p.ControllerID, bootstrapParams)
-	fullImageName := spec.GetFullImagePath(config.Config.ContainerRegistry, bootstrapParams.Image)
 	resourceRequirements := spec.FlavorToResourceRequirements(bootstrapParams.Flavor)
 
 	gitHubScopeDetails, err := spec.ExtractGitHubScopeDetails(bootstrapParams.RepoURL)
@@ -56,7 +55,7 @@ func (p Provider) CreateInstance(_ context.Context, bootstrapParams params.Boots
 			Containers: []corev1.Container{
 				{
 					Name:            "runner",
-					Image:           fullImageName,
+					Image:           bootstrapParams.Image,
 					Resources:       resourceRequirements,
 					Env:             envs,
 					ImagePullPolicy: corev1.PullAlways,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -41,9 +41,8 @@ func TestCreateInstance(t *testing.T) {
 		{
 			name: "Valid bootstrapParams and merge pod template spec",
 			config: &config.ProviderConfig{
-				KubeConfigPath:    "",
-				ContainerRegistry: "localhost:5000",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "",
+				RunnerNamespace: "runner",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -99,7 +98,7 @@ func TestCreateInstance(t *testing.T) {
 				InstanceToken:    "test-token",
 				MetadataURL:      "https://metadata.test",
 				CallbackURL:      "https://callback.test/status",
-				Image:            "runner:ubuntu-22.04",
+				Image:            "localhost:5000/runner:ubuntu-22.04",
 				OSType:           "linux",
 				OSArch:           "arm64",
 				Labels:           []string{"road-runner", "linux", "arm64", "kubernetes"},
@@ -258,9 +257,8 @@ func TestCreateInstance(t *testing.T) {
 		{
 			name: "Valid bootstrapParams and merge pod template spec with added sidecar",
 			config: &config.ProviderConfig{
-				KubeConfigPath:    "",
-				ContainerRegistry: "localhost:5000",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "",
+				RunnerNamespace: "runner",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -305,7 +303,7 @@ func TestCreateInstance(t *testing.T) {
 				InstanceToken: "test-token",
 				MetadataURL:   "https://metadata.test",
 				CallbackURL:   "https://callback.test/status",
-				Image:         "runner:ubuntu-22.04",
+				Image:         "localhost:5000/runner:ubuntu-22.04",
 				OSType:        "linux",
 				OSArch:        "arm64",
 				Labels:        []string{"road-runner", "linux", "arm64", "kubernetes"},
@@ -454,9 +452,8 @@ func TestCreateInstance(t *testing.T) {
 		{
 			name: "Valid bootstrapParams no pod template spec",
 			config: &config.ProviderConfig{
-				KubeConfigPath:    "",
-				ContainerRegistry: "localhost:5000",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "",
+				RunnerNamespace: "runner",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{},
@@ -471,7 +468,7 @@ func TestCreateInstance(t *testing.T) {
 				InstanceToken: "test-token",
 				MetadataURL:   "https://metadata.test",
 				CallbackURL:   "https://callback.test/status",
-				Image:         "runner:ubuntu-22.04",
+				Image:         "localhost:5000/runner:ubuntu-22.04",
 				OSType:        "linux",
 				OSArch:        "arm64",
 				Labels:        []string{"road-runner", "linux", "arm64", "kubernetes"},
@@ -597,9 +594,8 @@ func TestCreateInstance(t *testing.T) {
 		{
 			name: "Valid bootstrapParams and merge pod template spec with livenessProbe",
 			config: &config.ProviderConfig{
-				KubeConfigPath:    "",
-				ContainerRegistry: "localhost:5000",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "",
+				RunnerNamespace: "runner",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -633,7 +629,7 @@ func TestCreateInstance(t *testing.T) {
 				InstanceToken:    "test-token",
 				MetadataURL:      "https://metadata.test",
 				CallbackURL:      "https://callback.test/status",
-				Image:            "runner:ubuntu-22.04",
+				Image:            "localhost:5000/runner:ubuntu-22.04",
 				OSType:           "linux",
 				OSArch:           "arm64",
 				Labels:           []string{"road-runner", "linux", "arm64", "kubernetes"},
@@ -775,9 +771,8 @@ func TestCreateInstance(t *testing.T) {
 		{
 			name: "Valid bootstrapParams and custom flavors",
 			config: &config.ProviderConfig{
-				KubeConfigPath:    "",
-				ContainerRegistry: "localhost:5000",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "",
+				RunnerNamespace: "runner",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -831,7 +826,7 @@ func TestCreateInstance(t *testing.T) {
 				InstanceToken:    "test-token",
 				MetadataURL:      "https://metadata.test",
 				CallbackURL:      "https://callback.test/status",
-				Image:            "runner:ubuntu-22.04",
+				Image:            "localhost:5000/runner:ubuntu-22.04",
 				OSType:           "linux",
 				OSArch:           "arm64",
 				Labels:           []string{"road-runner", "linux", "arm64", "kubernetes"},
@@ -1019,9 +1014,8 @@ func TestGetInstance(t *testing.T) {
 		{
 			name: "Get Instance",
 			config: &config.ProviderConfig{
-				KubeConfigPath:    "",
-				ContainerRegistry: "localhost:5000",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "",
+				RunnerNamespace: "runner",
 			},
 			expectedProviderInstance: params.ProviderInstance{
 				ProviderID: providerID,
@@ -1176,9 +1170,8 @@ func TestDeleteInstance(t *testing.T) {
 		{
 			name: "Delete Instance Success",
 			config: &config.ProviderConfig{
-				KubeConfigPath:    "",
-				ContainerRegistry: "localhost:5000",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "",
+				RunnerNamespace: "runner",
 			},
 			runtimeObjects: []runtime.Object{
 				&corev1.Pod{
@@ -1353,9 +1346,8 @@ func TestRemoveAllInstances(t *testing.T) {
 		{
 			name: "Remove All Instances Success",
 			config: &config.ProviderConfig{
-				KubeConfigPath:    "",
-				ContainerRegistry: "localhost:5000",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "",
+				RunnerNamespace: "runner",
 			},
 			runtimeObjects: []runtime.Object{
 				&corev1.Pod{

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -5,7 +5,6 @@ package spec
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"unicode"
 
@@ -277,9 +276,4 @@ func ExtractImageDetails(pod *corev1.Pod) *ImageDetails {
 		OSVersion: OSVersion(pod.Labels[GarmOSVersionLabel]),
 		OSArch:    OSArch(pod.Labels[GarmOSArchLabel]),
 	}
-}
-
-func GetFullImagePath(containerRegistry, imageNameAndTag string) string {
-	reg := filepath.Clean(containerRegistry)
-	return reg + "/" + imageNameAndTag
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,11 +17,11 @@ import (
 )
 
 type ProviderConfig struct {
-	KubeConfigPath    string                                 `koanf:"kubeConfigPath"`
-	ContainerRegistry string                                 `koanf:"containerRegistry"`
-	RunnerNamespace   string                                 `koanf:"runnerNamespace"`
-	PodTemplate       corev1.PodTemplateSpec                 `koanf:"podTemplate"`
-	Flavors           map[string]corev1.ResourceRequirements `koanf:"flavors"`
+	KubeConfigPath string `koanf:"kubeConfigPath"`
+	//ContainerRegistry string                                 `koanf:"containerRegistry"`
+	RunnerNamespace string                                 `koanf:"runnerNamespace"`
+	PodTemplate     corev1.PodTemplateSpec                 `koanf:"podTemplate"`
+	Flavors         map[string]corev1.ResourceRequirements `koanf:"flavors"`
 }
 
 var Config ProviderConfig

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,8 +17,7 @@ import (
 )
 
 type ProviderConfig struct {
-	KubeConfigPath string `koanf:"kubeConfigPath"`
-	//ContainerRegistry string                                 `koanf:"containerRegistry"`
+	KubeConfigPath  string                                 `koanf:"kubeConfigPath"`
 	RunnerNamespace string                                 `koanf:"runnerNamespace"`
 	PodTemplate     corev1.PodTemplateSpec                 `koanf:"podTemplate"`
 	Flavors         map[string]corev1.ResourceRequirements `koanf:"flavors"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,9 +24,8 @@ func TestGetConfig(t *testing.T) {
 		{
 			name: "valid configuration withouth PodTemplateSpec",
 			expected: config.ProviderConfig{
-				KubeConfigPath:    "/path/to/kubeconfig",
-				ContainerRegistry: "sample.registry.com",
-				RunnerNamespace:   "test-namespace",
+				KubeConfigPath:  "/path/to/kubeconfig",
+				RunnerNamespace: "test-namespace",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{},
@@ -35,16 +34,14 @@ func TestGetConfig(t *testing.T) {
 			},
 			config: `
 kubeConfigPath: "/path/to/kubeconfig"
-containerRegistry: "sample.registry.com"
 runnerNamespace: "test-namespace"
 `,
 		},
 		{
 			name: "valid configuration - expect default namespace",
 			expected: config.ProviderConfig{
-				KubeConfigPath:    "/path/to/kubeconfig",
-				ContainerRegistry: "sample.registry.com",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "/path/to/kubeconfig",
+				RunnerNamespace: "runner",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{},
@@ -53,15 +50,13 @@ runnerNamespace: "test-namespace"
 			},
 			config: `
 kubeConfigPath: "/path/to/kubeconfig"
-containerRegistry: "sample.registry.com"
 `,
 		},
 		{
 			name: "valid configuration without a defined registry is fine - using configured container runtime registries",
 			expected: config.ProviderConfig{
-				KubeConfigPath:    "/path/to/kubeconfig",
-				ContainerRegistry: "",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "/path/to/kubeconfig",
+				RunnerNamespace: "runner",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{},
@@ -70,16 +65,14 @@ containerRegistry: "sample.registry.com"
 			},
 			config: `
 kubeConfigPath: "/path/to/kubeconfig"
-containerRegistry: ""
 runnerNamespace: "runner"
 `,
 		},
 		{
 			name: "invalid configuration with a invalid namespace name",
 			expected: config.ProviderConfig{
-				KubeConfigPath:    "/path/to/kubeconfig",
-				ContainerRegistry: "",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "/path/to/kubeconfig",
+				RunnerNamespace: "runner",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{},
@@ -88,7 +81,6 @@ runnerNamespace: "runner"
 			},
 			config: `
 kubeConfigPath: "/path/to/kubeconfig"
-containerRegistry: ""
 runnerNamespace: "this_is_An_invalid_namespace_name"
 `,
 			wantError: true,
@@ -96,9 +88,8 @@ runnerNamespace: "this_is_An_invalid_namespace_name"
 		{
 			name: "valid configuration with custom flavor to resource requirements mapping",
 			expected: config.ProviderConfig{
-				KubeConfigPath:    "/path/to/kubeconfig",
-				ContainerRegistry: "",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "/path/to/kubeconfig",
+				RunnerNamespace: "runner",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{},
@@ -127,7 +118,6 @@ runnerNamespace: "this_is_An_invalid_namespace_name"
 			},
 			config: `
 kubeConfigPath: "/path/to/kubeconfig"
-containerRegistry: ""
 runnerNamespace: "runner"
 flavors:
   micro:
@@ -148,9 +138,8 @@ flavors:
 		{
 			name: "valid configuration with extra livenessProbe",
 			expected: config.ProviderConfig{
-				KubeConfigPath:    "/path/to/kubeconfig",
-				ContainerRegistry: "",
-				RunnerNamespace:   "runner",
+				KubeConfigPath:  "/path/to/kubeconfig",
+				RunnerNamespace: "runner",
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -177,7 +166,6 @@ flavors:
 			},
 			config: `
 kubeConfigPath: "/path/to/kubeconfig"
-containerRegistry: ""
 runnerNamespace: "runner"
 podTemplate:
   spec:
@@ -213,7 +201,6 @@ podTemplate:
 
 			if tc.wantError == false && err == nil {
 				assert.Equal(t, tc.expected.KubeConfigPath, config.Config.KubeConfigPath)
-				assert.Equal(t, tc.expected.ContainerRegistry, config.Config.ContainerRegistry)
 				assert.Equal(t, tc.expected.RunnerNamespace, config.Config.RunnerNamespace)
 				assert.Equal(t, tc.expected.PodTemplate, config.Config.PodTemplate)
 				assert.Equal(t, tc.expected.Flavors, config.Config.Flavors)


### PR DESCRIPTION
For some reason we put the container registry config into the provider configuration (i think there was some max length validation in the past on garm side), whereas the tag of the image was definded in the  ImageCR respective Pool Entity in GARM.

This should now make ops and development easer, as one can define the desired image tag of the runner pod as a whole string like:

```yaml
apiVersion: garm-operator.mercedes-benz.com/v1alpha1
kind: Image
metadata:
  labels:
    app.kubernetes.io/instance: image-sample
    app.kubernetes.io/name: image
    app.kubernetes.io/part-of: garm-operator
  name: runner-default
  namespace: garm-operator-system
spec:
  tag: localhost:5000/runner-default:main-49fe84a
```