### PR TITLE
fix: upstream image fails due to missing files

### DIFF
--- a/runner/upstream/Dockerfile
+++ b/runner/upstream/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-FROM ghcr.io/actions/actions-runner:2.311.0
+FROM ghcr.io/actions/actions-runner:2.317.0
 
 USER root
 


### PR DESCRIPTION
This change fixes a number of bugs that prevent the image from working:

* The RUNNER_ASSETS_DIR doesn't seem to be set by default, so the image will fail when trying to copy the runner files.
* RUNNER_HOME seems to default to /runner
* The image we're basing this on, already has the runner files in /home/runner
* Change the default RUNNER_ASSETS_DIR to point to /home/runner. That way, even if no RUNNER_ASSETS_DIR is explicitly set, we can still copy the runner the image is based on.
* check_runner wasn't being called for JIT configs, which meant that when JIT was used, runners in GARM would be stuck in "installing" due to the fact that the setup process never calls home with system info and with a success message.