### PR TITLE
fix(runner): align entrypoint scripts, retrieve agent_id if configured via JIT

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -3,7 +3,7 @@
 FROM golang:1.22.4 AS build
 
 ARG garm_repo=https://github.com/cloudbase/garm
-ARG garm_repo_ref=main
+ARG garm_repo_ref=v0.1.4
 
 # build garm binary
 # primarly used to get the binary build for

--- a/runner/summerwind/Dockerfile
+++ b/runner/summerwind/Dockerfile
@@ -4,10 +4,12 @@ FROM summerwind/actions-runner:ubuntu-22.04
 
 USER root
 
-COPY my-entrypoint.sh /usr/local/bin/
+RUN apt-get update && apt-get install -y curl && apt-get clean
 
-RUN chmod +x /usr/local/bin/my-entrypoint.sh
+COPY entrypoint.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 USER 1001
 
-ENTRYPOINT ["/usr/local/bin/my-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
If runner was configured via JIT, the file under `/runner/.runner` which contains the `agent_id` has a different format compared to registering the runner via registration token, so the agent_id reported back to `garm` was `null`. This has been addressed now.
Also check_runner did not continue until `max_retry` on non-zero exit or pipefail.