### PR TITLE
chore: switch to new blackduck URL and new version

### DIFF
--- a/hack/scripts/foss-scan.sh
+++ b/hack/scripts/foss-scan.sh
@@ -77,7 +77,7 @@ mkdir -p "tmp/"
 
 echo "create bd scan ${BLACKDUCK_SCAN_VERSION_NAME}"
 set +e
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) \
+bash <(curl -s -L https://detect.blackduck.com/detect10.sh) \
     --blackduck.url="${BLACKDUCK_URL}" \
     --blackduck.api.token="${BLACKDUCK_TOKEN}" \
     --detect.project.name="${BLACKDUCK_PROJECT_NAME}" \


### PR DESCRIPTION
as synopsis has changed their product name and with that the URL we have to change the endpoint.

with that, we've also switched to the new detect script version