### PR TITLE
feat: allow override of volume and volumemount

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,6 +22,10 @@ import (
 	"github.com/mercedes-benz/garm-provider-k8s/pkg/diff"
 )
 
+const (
+	runnerContainerName = "runner"
+)
+
 type Provider struct {
 	ControllerID  string
 	ClientSet     kubernetes.Interface
@@ -54,7 +58,7 @@ func (p Provider) CreateInstance(_ context.Context, bootstrapParams params.Boots
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{
 				{
-					Name:            "runner",
+					Name:            runnerContainerName,
 					Image:           bootstrapParams.Image,
 					Resources:       resourceRequirements,
 					Env:             envs,
@@ -70,6 +74,11 @@ func (p Provider) CreateInstance(_ context.Context, bootstrapParams params.Boots
 	}
 
 	err = spec.CreateRunnerVolume(pod)
+	if err != nil {
+		return params.ProviderInstance{}, err
+	}
+
+	err = spec.CreateRunnerVolumeMount(pod, runnerContainerName)
 	if err != nil {
 		return params.ProviderInstance{}, err
 	}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -5,6 +5,7 @@ package spec
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"unicode"
 
@@ -222,7 +223,7 @@ func CreateRunnerVolumeMount(pod *corev1.Pod, runnerContainerName string) error 
 			for _, volMounts := range container.VolumeMounts {
 				// Volumemount paths e.g. /runner and /runner/ are threated equal
 				// The last one in the pod spec will take precedence, which can lead to unexpected behavior
-				if volMounts.MountPath == runnerVolumeMountPath || volMounts.MountPath == runnerVolumeMountPath+"/" {
+				if volMounts.MountPath == filepath.Clean(runnerVolumeMountPath) {
 					return nil
 				}
 			}


### PR DESCRIPTION
This PR ensures, that the default volume and volumemount wont be created, if they are defined in podtemplate to e.g. use an PVC instead of an emptydir
